### PR TITLE
Make it more clear that users *need* an execution client.

### DIFF
--- a/website/docs/About/Clients.md
+++ b/website/docs/About/Clients.md
@@ -14,13 +14,13 @@ Currently supported consensus clients:
 - Lodestar
 - Prysm - client has close to a supermajority, it is recommended to choose any other
 
-Currently supported (optional until merge) execution clients:
-- Geth, local execution client
-- Erigon, local execution client - for testing. Feedback welcome.
-- Besu, local execution client - Feedback welcome.
-- Nethermind, local execution client - Feedback welcome.
+Currently supported execution clients:
+- Geth - client has a supermajority, it is **strongly** recommended to choose any other
+- Erigon
+- Besu
+- Nethermind
 
-> Use one of the local execution client options or a 3rd-party provider of Ethereum chain data to "feed"
+> Use one of the local execution client options to "feed"
 > your consensus client, so you can [propose](https://ethos.dev/beacon-chain/) blocks.
 
 Currently supported additional options:


### PR DESCRIPTION
With the merge closing in on it, anyone setting up a client at this time should not be using a third party execution layer.  I removed the optionality, removed references to third party data providers, and removed the optionality of execution clients.

This has PR #149 baked in, feel free to close that one if this is merged first, or I can rebase if that one is merged first.