### PR TITLE
Update link to MEV relay list

### DIFF
--- a/website/docs/Usage/ClientSetup.md
+++ b/website/docs/Usage/ClientSetup.md
@@ -197,7 +197,7 @@ These are largely for running RPC nodes, instead of validator nodes. Most users 
 
 ### MEV Boost
 
-Your Consensus Layer client connects to the mev-boost container. If you are running a CL in eth-docker, then in `.env` you'd add `mev-boost.yml` to `COMPOSE_FILE`, set `MEV_BOOST=true` and set `MEV_RELAYS` to the [relays you wish to use](https://ethstaker.cc/mev-relay-list/).
+Your Consensus Layer client connects to the mev-boost container. If you are running a CL in eth-docker, then in `.env` you'd add `mev-boost.yml` to `COMPOSE_FILE`, set `MEV_BOOST=true` and set `MEV_RELAYS` to the [relays you wish to use](https://github.com/eth-educators/ethstaker-guides/blob/main/MEV-relay-list.md).
 
 If you are running a validator client only, such as with a RocketPool "reverse hybrid" setup, then all you need to do is to set `MEV_BOOST=true` in `.env`. `mev-boost.yml` and `MEV_RELAYS` are not needed and won't be used if they are set, as they are relevant only where the Consensus Layer client runs. See the [Overview](/) drawing for how these components communicate.
 


### PR DESCRIPTION
Current link to MEV relay list does not work as website http://ethstaker.cc/ is offline. Probably anyhow best to reference to the github repository it this is most likely to be up-to-date.