### PR TITLE
Add Lodestar to client resource usage

### DIFF
--- a/website/docs/Usage/ResourceUsage.md
+++ b/website/docs/Usage/ResourceUsage.md
@@ -12,6 +12,7 @@ sidebar_label: Client Resource Usage
 | Lighthouse | 2.1.1  | Jan 2022 | ~90 GiB | ~1.7 GiB | 50-200% | |
 | Nimbus | 1.6.0 | Jan 2022 | ~40 GiB | ~2.3 GiB | 50-200% | |
 | Prysm | 2.1.3 | Jul 2022 | ~100 GiB | ~4 GiB | 100-300% | |
+| Lodestar | 1.3.0 | Jan 2023 | ~30 GiB | ~4 GiB | 50-150% | |
 
 # Execution clients
 


### PR DESCRIPTION
Adds Lodestar to client resource usage docs. I documented slightly higher values than the measurements shown below to consider resource spikes.

![image](https://user-images.githubusercontent.com/38436224/213151095-34a62fd0-8217-45e3-a4d0-681d0b6a0a54.png)


## Measurements

### DB Size (checkpoint sync)

![image](https://user-images.githubusercontent.com/38436224/213149271-6ac41c3e-5a4e-4048-8cab-e1a63a541bc1.png)

![image](https://user-images.githubusercontent.com/38436224/213152403-545f26e4-6a46-458d-b87e-a3931f205eb6.png)

### RAM

![image](https://user-images.githubusercontent.com/38436224/213149904-d86ad918-6edb-42f9-af36-26eef5ad3e38.png)

![image](https://user-images.githubusercontent.com/38436224/213150106-957c279e-a5f4-42e5-bfc2-92ab5e199788.png)

### CPU

![image](https://user-images.githubusercontent.com/38436224/213150519-754abf10-d0da-4858-a398-e96a3ab3dafc.png)


@philknows @dapplion @tuyennhv