### PR TITLE
Remove unnecessary action from step 1a in SwitchClient.md

### DIFF
--- a/website/docs/Support/SwitchClient.md
+++ b/website/docs/Support/SwitchClient.md
@@ -40,8 +40,6 @@ Move the `_data` directory in the **old** volume to the new database location: `
 
 Start the new stack again: `./ethd up`, then observe that your execution client is running well and is synced to head: `./ethd logs -f execution`.
 
-Finally, remove the old volume: `docker volume rm OLDVOLUME`, e.g. for Geth `docker volume rm eth-docker_geth-eth1-data`.
-
 ### 2. Move your validators
 
 **Exercise extreme caution. Running your validators in two locations at once would lead to slashing**


### PR DESCRIPTION
The action to remove the old execution client volume will prevent the user from completing the steps in "Moving a Validator" => "Bring down and old client" because the `./ethd keys list` command will fail.

Additionally, the last action in "Bring down and old client" is a duplicate of this step: `docker volume rm VOLUMENAME`