### PR TITLE
fix: changed withdrawal credentials to official staking launchpad

### DIFF
--- a/website/docs/About/Overview.md
+++ b/website/docs/About/Overview.md
@@ -48,6 +48,8 @@ When setting up an Ethereum staking full node, you'll:
 - Once the Ethereum execution client and consensus client are fully synced with the chain, deposit Ethereum
   at the launchpad, 32 ETH per validator key.
 
+* Note on Görli: Görli testnet is in rough shape and it is quite difficult to get the required 32 eth to setup a validator on the testnet. 
+
 Here's what then happens:
 
 - The chain processes the deposit and activates the validators: Your validators start earning rewards

--- a/website/docs/Support/ChangingWithdrawalCredentials.md
+++ b/website/docs/Support/ChangingWithdrawalCredentials.md
@@ -10,7 +10,7 @@ Eth Docker supports using ethdo in an online/offline fashion to prepare withdraw
 
 ## Check whether your validator has a withdrawal address set
 
-[Metrika](https://app.metrika.co/ethereum/dashboard/withdrawals-overview) will let you see whether your validator has a withdrawal address set. If yes, that is where consensus layer rewards will be swept automatically (every 4-5 days at ~500,000 validators total) and where your funds will be sent when exiting.
+[Ethereum's Staking Launchpad](https://launchpad.ethereum.org/en/withdrawals) will let you see whether your validator has a withdrawal address set. If yes, that is where consensus layer rewards will be swept automatically (every 4-5 days at ~500,000 validators total) and where your funds will be sent when exiting.   
 
 You can use `./ethd keys list` to get a list of your validator public keys that are currently active on your system.
 

--- a/website/docs/Support/HelpfulWebsites.md
+++ b/website/docs/Support/HelpfulWebsites.md
@@ -1,0 +1,28 @@
+---
+id: HelpfulWebsites
+title: Helpful Websites
+sidebar_label: Helpful Websites
+---
+
+## EthStaker
+[https://ethstaker.cc/](https://ethstaker.cc/) - EthStaker website
+
+[https://ethstaker.cc/support](https://ethstaker.cc/support) - Social media links
+
+## Educational
+
+[https://launchpad.ethereum.org/en/](https://launchpad.ethereum.org/en/) - Official Staking Launchpad website
+
+[https://ethereum.org/en/staking/](https://ethereum.org/en/staking/) - Broad overview of ETH staking
+
+[https://ethereum.org/en/run-a-node/](https://ethereum.org/en/run-a-node/) - Running a validator on Ethereum requires running a node first.
+
+## Monitoring
+
+[https://www.validatorqueue.com/](https://www.validatorqueue.com/) - The Ethereum validator entry and exit queues have varying waiting times depending on the state of the network. The entry queue has historically reached as long as 45 days.
+
+[https://beaconcha.in/](https://beaconcha.in/) - Track the stats of your validator on the Beacon Chain, including waiting times, deposits and withdrawals, and overall performance. If you create an account, you can also monitor your validator to receive email notifications for any potential problems.
+
+[https://launchpad.ethereum.org/en/withdrawals](https://launchpad.ethereum.org/en/withdrawals) - Check your validator's withdrawal credentials
+
+

--- a/website/docs/Usage/QuickStart.md
+++ b/website/docs/Usage/QuickStart.md
@@ -15,7 +15,7 @@ Take a look at some [build ideas](../Usage/Hardware.md) and consider clients' [r
 ## Eth Docker QuickStart
 
 For a rapid start, have Ubuntu or Debian Linux installed, and then follow these steps. This has been tested on Ubuntu
-20.04/22.04 and Debian 11/12.
+20.04/22.04 and Debian 11/12. 
 
 Download Eth Docker
 
@@ -48,6 +48,8 @@ If you are going to run a validating node, [create and import keys](../Usage/Imp
 Forward the [P2P ports](../Usage/Networking.md) that the clients use.
 
 Consider your [Linux security](../Usage/LinuxSecurity.md)
+
+Deposit your 32 ETH using the official [Staking Launchpad](https://launchpad.ethereum.org/en/).
 
 ## Advanced use
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -36,7 +36,8 @@
             "Support/Rocketpool",
             "Support/SSV",
             "Support/Windows",
-            "Support/ipv6"
+            "Support/ipv6",
+            "Support/HelpfulWebsites"
         ]
     }
 }


### PR DESCRIPTION
fix: changed withdrawal credentials to official staking launchpad
feat: added HelpfulWebsites.md

Hi Yorick,

I did some small edits to make the docs a bit more clear from my own experience spinning up a couple regulators using your amazing eth-docker work! I also added a helpful website section since I thought after the node was up and running I was just a touch lost on how to proceed.

Thanks again,
Kaveh